### PR TITLE
Implement serialnoflow option

### DIFF
--- a/src-pos/uk/chromis/pos/config/JPanelConfigPeripheral.java
+++ b/src-pos/uk/chromis/pos/config/JPanelConfigPeripheral.java
@@ -143,6 +143,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter1.addItem("javapos");
 
         jcboConnPrinter1.addItem("serial");
+        jcboConnPrinter1.addItem("serialnoflow");
         jcboConnPrinter1.addItem("file");
         jcboConnPrinter1.addItem("raw");
         jcboConnPrinter1.addItem("usb");
@@ -160,6 +161,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter2.addItem("javapos");
 
         jcboConnPrinter2.addItem("serial");
+        jcboConnPrinter2.addItem("serialnoflow");
         jcboConnPrinter2.addItem("file");
         jcboConnPrinter2.addItem("raw");
         jcboConnPrinter2.addItem("usb");
@@ -177,6 +179,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter3.addItem("javapos");
 
         jcboConnPrinter3.addItem("serial");
+        jcboConnPrinter3.addItem("serialnoflow");
         jcboConnPrinter3.addItem("file");
         jcboConnPrinter3.addItem("raw");
         jcboConnPrinter3.addItem("usb");
@@ -194,6 +197,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter4.addItem("javapos");
 
         jcboConnPrinter4.addItem("serial");
+        jcboConnPrinter4.addItem("serialnoflow");
         jcboConnPrinter4.addItem("file");
         jcboConnPrinter4.addItem("raw");
         jcboConnPrinter4.addItem("usb");
@@ -211,6 +215,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter5.addItem("javapos");
 
         jcboConnPrinter5.addItem("serial");
+        jcboConnPrinter5.addItem("serialnoflow");
         jcboConnPrinter5.addItem("file");
         jcboConnPrinter5.addItem("raw");
         jcboConnPrinter5.addItem("usb");
@@ -228,6 +233,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachinePrinter6.addItem("javapos");
 
         jcboConnPrinter6.addItem("serial");
+        jcboConnPrinter6.addItem("serialnoflow");
         jcboConnPrinter6.addItem("file");
         jcboConnPrinter6.addItem("raw");
         jcboConnPrinter6.addItem("usb");
@@ -242,6 +248,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         jcboMachineDisplay.addItem("surepos");
 
         jcboConnDisplay.addItem("serial");
+        jcboConnDisplay.addItem("serialnoflow");
         jcboConnDisplay.addItem("file");
         jcboConnDisplay.addItem("raw");
         jcboConnDisplay.addItem("usb");
@@ -356,6 +363,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
 
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter1.setSelectedItem("epson");
                 jcboConnPrinter1.setSelectedItem(sparam);
@@ -381,6 +389,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter2.setSelectedItem("epson");
                 jcboConnPrinter2.setSelectedItem(sparam);
@@ -406,6 +415,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter3.setSelectedItem("epson");
                 jcboConnPrinter3.setSelectedItem(sparam);
@@ -432,6 +442,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter4.setSelectedItem("epson");
                 jcboConnPrinter4.setSelectedItem(sparam);
@@ -457,6 +468,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter5.setSelectedItem("epson");
                 jcboConnPrinter5.setSelectedItem(sparam);
@@ -482,6 +494,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachinePrinter6.setSelectedItem("epson");
                 jcboConnPrinter6.setSelectedItem(sparam);
@@ -507,6 +520,7 @@ public class JPanelConfigPeripheral extends javax.swing.JPanel implements PanelC
         sparam = unifySerialInterface(p.nextToken(':'));
         switch (sparam) {
             case "serial":
+            case "serialnoflow":
             case "file":
                 jcboMachineDisplay.setSelectedItem("epson");
                 jcboConnDisplay.setSelectedItem(sparam);

--- a/src-pos/uk/chromis/pos/printer/DeviceTicket.java
+++ b/src-pos/uk/chromis/pos/printer/DeviceTicket.java
@@ -117,7 +117,7 @@ public class DeviceTicket {
         String sDisplayParam1 = sd.nextToken(',');
         String sDisplayParam2 = sd.nextToken(',');
 
-        if ("serial".equals(sDisplayType) || "rxtx".equals(sDisplayType) || "file".equals(sDisplayType)) {
+        if ("serial".equals(sDisplayType) || "serialnoflow".equals(sDisplayType) || "rxtx".equals(sDisplayType) || "file".equals(sDisplayType)) {
             sDisplayParam2 = sDisplayParam1;
             sDisplayParam1 = sDisplayType;
             sDisplayType = "epson";
@@ -170,7 +170,7 @@ public class DeviceTicket {
             String sPrinterParam1 = sp.nextToken(',');
             String sPrinterParam2 = sp.nextToken(',');
 
-            if ("serial".equals(sPrinterType) || "rxtx".equals(sPrinterType) || "file".equals(sPrinterType)) {
+            if ("serial".equals(sPrinterType) || "serialnoflow".equals(sPrinterType) || "rxtx".equals(sPrinterType) || "file".equals(sPrinterType)) {
                 sPrinterParam2 = sPrinterParam1;
                 sPrinterParam1 = sPrinterType;
                 sPrinterType = "epson";
@@ -248,6 +248,10 @@ public class DeviceTicket {
                     case "serial":
                     case "rxtx":
                         pw = new PrinterWritterRXTX(port);
+                        m_apool.put(skey, pw);
+                        break;
+                    case "serialnoflow":
+                        pw = new PrinterWritterRXTX(port, 0);
                         m_apool.put(skey, pw);
                         break;
                     case "file":

--- a/src-pos/uk/chromis/pos/printer/escpos/PrinterWritterRXTX.java
+++ b/src-pos/uk/chromis/pos/printer/escpos/PrinterWritterRXTX.java
@@ -41,15 +41,26 @@ public class PrinterWritterRXTX extends PrinterWritter /* implements SerialPortE
     
     private String m_sPortPrinter;
     private OutputStream m_out;
+    private int m_flowcontrol;
     
     /** Creates a new instance of PrinterWritterComm
      * @param sPortPrinter
      * @throws uk.chromis.pos.printer.TicketPrinterException */
     public PrinterWritterRXTX(String sPortPrinter) throws TicketPrinterException {
         m_sPortPrinter = sPortPrinter;
-        m_out = null; 
+        m_out = null;
+	m_flowcontrol = 1;
     }
     
+    /** Creates a new instance of PrinterWritterComm
+     * @param sPortPrinter
+     * @throws uk.chromis.pos.printer.TicketPrinterException */
+    public PrinterWritterRXTX(String sPortPrinter, int flowcontrol) throws TicketPrinterException {
+        m_sPortPrinter = sPortPrinter;
+        m_out = null;
+	m_flowcontrol = flowcontrol;
+    }
+
     /**
      *
      * @param data
@@ -59,25 +70,21 @@ public class PrinterWritterRXTX extends PrinterWritter /* implements SerialPortE
         try {  
             if (m_out == null) {
                 m_PortIdPrinter = CommPortIdentifier.getPortIdentifier(m_sPortPrinter); // Tomamos el puerto                   
-                m_CommPortPrinter = m_PortIdPrinter.open("PORTID", 2000); // Abrimos el puerto       
-
+                m_CommPortPrinter = m_PortIdPrinter.open("PORTID", 10000); // Abrimos el puerto       
                 m_out = m_CommPortPrinter.getOutputStream(); // Tomamos el chorro de escritura   
-
                 if (m_PortIdPrinter.getPortType() == CommPortIdentifier.PORT_SERIAL) {
                     ((SerialPort)m_CommPortPrinter).setSerialPortParams(9600, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE); // Configuramos el puerto
-                    ((SerialPort)m_CommPortPrinter).setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN);  // this line prevents the printer tmu220 to stop printing after +-18 lines printed
-                    // this line prevents the printer tmu220 to stop printing after +-18 lines printed. Bug 8324
-                    // But if added a regression error appears. Bug 9417, Better to keep it commented.
-                    // ((SerialPort)m_CommPortPrinter).setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN);
-    // Not needed to set parallel properties
-    //                } else if (m_PortIdPrinter.getPortType() == CommPortIdentifier.PORT_PARALLEL) {
-    //                    ((ParallelPort)m_CommPortPrinter).setMode(1);
-
+                    if (m_flowcontrol == 1) {
+                	((SerialPort)m_CommPortPrinter).setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN);  // this line prevents the printer tmu220 to stop printing after +-18 lines printed
+                    }
                 }
             }
             m_out.write(data);
+            //String str = new String(data, "UTF-8");
+            //System.out.println("Display write "+str);
         } catch (NoSuchPortException | PortInUseException | UnsupportedCommOperationException | IOException e) {
             System.err.println(e);
+            System.out.println(e);
         }      
     }
     


### PR DESCRIPTION
As i noticed many people experienced problems with inexpensive USB VFD display, as i.
After digging a bit code, i found out that in PrinterWritter it is settings flow control in Serial, which is usually not implemented in cheap USB-Serial dongles.

As this flowcontrol seems essential, i wrote patch to implement new option for serial.